### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ func main() {
 
 ## Setting custom HTTP client
 
-```
+```go
 customClient := &http.Client{Timeout: 10 * time.Second}
 paprikaClient := coinpaprika.NewClient(customClient)
 ```


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.