### PR TITLE
docs: add Installation section and fix v2 import path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This library provides convenient way to use [coinpaprika.com API](https://api.co
 
 [Coinpaprika](https://coinpaprika.com) delivers full market data to the world of crypto: coin prices, volumes, market caps, ATHs, return rates and more.
 
+## Installation
+
+```sh
+go get github.com/coinpaprika/coinpaprika-api-go-client/v2
+```
+
 ## Getting started
 
 ```go
@@ -19,7 +25,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/coinpaprika/coinpaprika-api-go-client/coinpaprika"
+	"github.com/coinpaprika/coinpaprika-api-go-client/v2/coinpaprika"
 )
 
 func main() {


### PR DESCRIPTION
## What
- Adds a missing **Installation** section to the README.
- Fixes the **Getting started** example's import path.

## Why
- There was no `go get` instruction anywhere in the README.
- The example imported `github.com/coinpaprika/coinpaprika-api-go-client/coinpaprika` — without the `/v2` suffix. Since `go.mod` declares the module as `github.com/coinpaprika/coinpaprika-api-go-client/v2`, that import **does not compile**; Go requires the major-version suffix in the path. The repo's own example/test code already uses the `/v2/coinpaprika` form.

## Changes
```
go get github.com/coinpaprika/coinpaprika-api-go-client/v2
```
and the example import becomes `.../coinpaprika-api-go-client/v2/coinpaprika`.

## Verification
Extracted the README's Getting started snippet and built it against the module (v2.5.0, via a `replace` to this tree) — compiles cleanly. The previous `/v2`-less import fails to resolve, confirming it was broken.
